### PR TITLE
Deprecation Error: Timers.unenroll() 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vagrant
+
+node_modules/

--- a/README.md
+++ b/README.md
@@ -56,6 +56,38 @@ There are several docker-compose services
 * `database` - just a stock mysql database so you don't have to install anything
 * `database-migration` - run database migration script to create and seed the jscity database
 * `jscity` - the web server itself
+* `generator` - used to run the city generator. Typically you would run this with the `run` and not the `up` command.
+
+#### Generate City
+
+Note that this isn't as easy as running `run-generate.sh` - this script is meant to be run *inside the docker container* not outside of it.
+
+The code to be scanned needs to be somewhere accessible to the generator docker container. You may mount additional volumes or simply place it in the cannonical location `js/backend/system/`.
+
+If you were to simply `docker-compose run` the application it will start with a new instance of the `database` service so that your changes will be created and immediately discarded. To bypass that limitation first start the database and run any migrations (if this is not your first time you can just up `database`)
+
+```
+docker-compose up -d database-migration
+```
+and then run without creating additional dependencies.
+
+Note that int he following examples we're just creating further versions of the jscity sample city
+
+```
+docker-compose run --rm --no-deps generator ./js/backend/system/metafora/ -c "Metafora Sample"
+```
+
+You may also append `--verbose` for more verbose output on the generation process.
+
+##### Debugging
+
+To debug `generator.js` you can pass in a `--debug` flag and don't forget to map port 9229
+
+```
+docker-compose run --rm -p 9229:9229 --no-deps generator ./js/backend/system/metafora/ -c "Metafora" --verbose --debug
+```
+
+This will start the script with the debugger and break on the very first line. You can navigate to `chrome://inspect/#devices` in Chrome to attach the debugger there.
 
 ### Vagrant setup
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cd /path-to-jscity-directory/js
 ```
 * Start the application server using the command.
 ```sh
-node server.js
+npm start
 ```
 * Using your browser, access the url below to open the jscity system:
 ```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ http://localhost:8888/
 ```
 * Select the system from the combobox and wait for the end of city design.
 
+### Docker setup
+
+If you would like it as a docker
+
+```
+docker-compose up jscity
+```
+
+then give it 15 seconds or so and `http://localhost:8888`
+
+There are several docker-compose services
+
+* `database` - just a stock mysql database so you don't have to install anything
+* `database-migration` - run database migration script to create and seed the jscity database
+* `jscity` - the web server itself
 
 ### Vagrant setup
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.6'
+services:
+  jscity:
+    image: node:13.0.1-stretch-slim
+    ports:
+      - '8888:8888'
+      - '9234:9234' # node debug port
+    volumes:
+      - '.:/app'
+    depends_on:
+      - database
+    working_dir: /app
+    command: 'npm start'
+  database:
+    image: mysql:8.0.18
+    ports:
+      - '3306:3306'
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+    volumes:
+      - './sql:/sql'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,3 +27,14 @@ services:
     environment:
       CREATE_TEST_CITY: 1
     command: 'bash -c "sleep 15 && mysql --host=database < ./sql/schema.sql"' #sleep to give the db time to come up
+  generator:
+    image: node:13.0.1-stretch-slim
+    ports:
+      - '9229:9229' # node debug port
+    volumes:
+      - '.:/app'
+    depends_on:
+      - database
+      - database-migration
+    working_dir: /app
+    entrypoint: './run-generator.sh'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - '.:/app'
     depends_on:
       - database
+      - database-migration
     working_dir: /app
     command: 'npm start'
   database:
@@ -17,5 +18,12 @@ services:
       - '3306:3306'
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+  database-migration:
+    image: mysql:8.0.18
+    depends_on:
+      - database
     volumes:
       - './sql:/sql'
+    environment:
+      CREATE_TEST_CITY: 1
+    command: 'bash -c "sleep 15 && mysql --host=database < ./sql/schema.sql"' #sleep to give the db time to come up

--- a/js/config.json
+++ b/js/config.json
@@ -1,6 +1,6 @@
 	{
 		"porta": 8888,
-		"debug": false,
+		"debug": true,
 		"conexao": "local",
 		"cache-local": false,
 		"expires": {
@@ -12,9 +12,9 @@
 			"local": {
 				"connectionLimit": 200,
 				"waitForConnections": true,
-				"host": "localhost",
+				"host": "database",
 				"user": "jscity",
-				"password": "",
+				"password": "password",
 				"database": "jscity"
 			},
 			"amazon": {

--- a/js/config.json
+++ b/js/config.json
@@ -1,6 +1,6 @@
 	{
 		"porta": 8888,
-		"debug": true,
+		"debug": false,
 		"conexao": "local",
 		"cache-local": false,
 		"expires": {

--- a/js/server.js
+++ b/js/server.js
@@ -248,6 +248,7 @@
 								sSQL = mysql.format(sSQL, format);
 								connection.query(sSQL, function(err, rows, fields) {
 									if(err) {
+										console.log(err)
 										responseObj.message = msg('Internal Error. {FCBD}', err.message);
 										writeEnd(JSON.stringify(responseObj), "application/json", 500);
 									} else {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
 		"node": ">= 0.12"
 	},
 	"scripts": {
-		"start": "node ./js/server.js"
+		"start": "node --inspect=0.0.0.0:9234 ./js/server.js"
 	}
 }

--- a/provision_script.sh
+++ b/provision_script.sh
@@ -1,4 +1,5 @@
-# provision_script.sh
+##!/bin/bash
+
 apt-get update
 debconf-set-selections <<< 'mysql-server mysql-server/root_password password your_password'
 debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password your_password'

--- a/run-generator.sh
+++ b/run-generator.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Runs generator.js to parse a city. Meant to be run from inside the docker-compose but if you have the application configured outside of it can work as well.
+# When the --debug flag is passed will start the node debugger and idle on the first line
+
+if [[ $* == *--debug* ]]; then
+	echo "Starting node debugger on port 9229"
+	echo "Navigate to chrome://inspect/#devices to connect, if you do not see it there and are running this via docker make sure you remembered to map -p 9229:9229"
+	node --inspect-brk=0.0.0.0:9229 ./js/backend/generator.js "$@"
+else
+	node ./js/backend/generator.js "$@"
+fi

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,9 +1,3 @@
-/*
-SQLyog 
-MySQL - 5.6.26 : Database - jscity
-*********************************************************************
-*/
-
 /*!40101 SET NAMES utf8 */;
 
 /*!40101 SET SQL_MODE=''*/;
@@ -12,7 +6,10 @@ MySQL - 5.6.26 : Database - jscity
 /*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
-CREATE DATABASE /*!32312 IF NOT EXISTS*/`jscity` /*!40100 DEFAULT CHARACTER SET latin1 */;
+CREATE DATABASE IF NOT EXISTS `jscity`;
+
+CREATE USER IF NOT EXISTS jscity IDENTIFIED WITH mysql_native_password BY 'password';
+GRANT ALL PRIVILEGES ON jscity.* TO jscity;
 
 USE `jscity`;
 


### PR DESCRIPTION
Hey how's it going? Thanks for the project and for the contribution by dockerizing it, however I can't make it work in any way, I've tried to change the node and mysql version a few times, but without success.

after running:
`docker-compose run --rm --no-deps generator ./js/backend/system/metafora/ -c "Metafora Sample"`

I get this error:

> Error: getaddrinfo ENOTFOUND database
>     at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:60:26)
>     --------------------
>     at Protocol._enqueue (/app/js/node_modules/mysql/lib/protocol/Protocol.js:135:48)
>     at Protocol.handshake (/app/js/node_modules/mysql/lib/protocol/Protocol.js:52:41)
>     at Connection.connect (/app/js/node_modules/mysql/lib/Connection.js:119:18)
>     at processAST (/app/js/backend/generator.js:434:13)
>     at Object.end (/app/js/backend/generator.js:131:19)
>     at /app/js/backend/generator.js:264:14
>     at FSReqCallback.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:61:3) {
>   errno: -3008,
>   code: 'ENOTFOUND',
>   syscall: 'getaddrinfo',
>   hostname: 'database',
>   fatal: true
> }
> (node:7) [DEP0096] DeprecationWarning: timers.unenroll() is deprecated. Please use clearTimeout instead.


Would you help me?